### PR TITLE
feat: add `string` type to `WorkflowDispatchInput` interface

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -46,7 +46,7 @@ interface WorkflowRunEventOptions {
 interface WorkflowDispatchInput {
   description: string;
   required?: boolean;
-  type?: "choice" | "boolean";
+  type?: "choice" | "boolean" | "string";
   options?: string[];
   default?: string | boolean;
 }


### PR DESCRIPTION
GitHub Actions support that type, and we will use it at Factorial.